### PR TITLE
Add basic support for EIP-5553 parent IP address

### DIFF
--- a/contracts/DCNT721A.sol
+++ b/contracts/DCNT721A.sol
@@ -40,6 +40,7 @@ contract DCNT721A is ERC721A, Initializable, Ownable, Splits {
 
   address public splitMain;
   address public splitWallet;
+  address public parentIP;
 
   /// ============ Events ============
 
@@ -66,6 +67,7 @@ contract DCNT721A is ERC721A, Initializable, Ownable, Splits {
     maxTokenPurchase = _editionConfig.maxTokenPurchase;
     royaltyBPS = _editionConfig.royaltyBPS;
     splitMain = _splitMain;
+    parentIP = _metadataConfig.parentIP;
 
     if (
       _metadataRenderer != address(0) &&

--- a/contracts/DCNTCrescendo.sol
+++ b/contracts/DCNTCrescendo.sol
@@ -70,6 +70,7 @@ contract DCNTCrescendo is
   /// @notice DCNTMetadataRenderer address
   address public metadataRenderer;
 
+  address public parentIP;
   /// ============ Constructor ============
 
   function initialize(
@@ -93,6 +94,7 @@ contract DCNTCrescendo is
     _symbol = _config.symbol;
     royaltyBPS = _config.royaltyBPS;
     splitMain = _splitMain;
+    parentIP = _metadataConfig.parentIP;
 
     if (
       _metadataRenderer != address(0) &&

--- a/contracts/DCNTSDK.sol
+++ b/contracts/DCNTSDK.sol
@@ -88,7 +88,7 @@ contract DCNTSDK is Ownable {
         "initialize("
           "address,"
           "(string,string,uint256,uint256,uint256,uint256),"
-          "(string,bytes),"
+          "(string,bytes,address),"
           "address,"
           "address"
         ")",
@@ -115,7 +115,7 @@ contract DCNTSDK is Ownable {
         "initialize("
           "address,"
           "(string,string,uint256,uint256,uint256,uint256),"
-          "(string,bytes),"
+          "(string,bytes,address),"
           "address,"
           "address"
         ")",
@@ -142,7 +142,7 @@ contract DCNTSDK is Ownable {
         "initialize("
           "address,"
           "(string,string,uint256,uint256,uint256,uint256,uint256,uint256,uint256),"
-          "(string,bytes),"
+          "(string,bytes,address),"
           "address,"
           "address"
         ")",

--- a/contracts/DCNTVaultNFT.sol
+++ b/contracts/DCNTVaultNFT.sol
@@ -72,7 +72,7 @@ contract DCNTVaultNFT is Ownable {
     if (_supports4907) {
       (bool success1, bytes memory data1) = _DCNTSDK.delegatecall(
         abi.encodeWithSignature(
-          "deployDCNT4907A((string,string,uint256,uint256,uint256,uint256),(string,bytes))",
+          "deployDCNT4907A((string,string,uint256,uint256,uint256,uint256),(string,bytes,address))",
           _editionConfig,
           _metadataConfig
         )
@@ -83,7 +83,7 @@ contract DCNTVaultNFT is Ownable {
     } else {
       (bool success2, bytes memory data2) = _DCNTSDK.delegatecall(
         abi.encodeWithSignature(
-          "deployDCNT721A((string,string,uint256,uint256,uint256,uint256),(string,bytes))",
+          "deployDCNT721A((string,string,uint256,uint256,uint256,uint256),(string,bytes,address))",
           _editionConfig,
           _metadataConfig
         )

--- a/contracts/storage/MetadataConfig.sol
+++ b/contracts/storage/MetadataConfig.sol
@@ -4,4 +4,5 @@ pragma solidity ^0.8.0;
 struct MetadataConfig {
   string metadataURI;
   bytes metadataRendererInit;
+  address parentIP;
 }

--- a/core/index.ts
+++ b/core/index.ts
@@ -101,6 +101,7 @@ export const deployDCNTVaultNFT = async (decentSDK: Contract) => {
   return await tx.deployed();
 }
 
+const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const deployDCNT721A = async (
   decentSDK: Contract,
   name: string,
@@ -110,7 +111,8 @@ export const deployDCNT721A = async (
   maxTokenPurchase: number,
   royaltyBPS: number,
   metadataURI: string,
-  metadata: MetadataInit | null
+  metadata: MetadataInit | null,
+  parentIP: string =EMPTY_ADDRESS
 ) => {
   const metadataRendererInit = metadata != null
     ? ethers.utils.AbiCoder.prototype.encode(
@@ -135,6 +137,7 @@ export const deployDCNT721A = async (
     {
       metadataURI,
       metadataRendererInit,
+      parentIP
     }
   );
 
@@ -152,7 +155,9 @@ export const deployDCNT4907A = async (
   maxTokenPurchase: number,
   royaltyBPS: number,
   metadataURI: string,
-  metadata: MetadataInit | null
+  metadata: MetadataInit | null,
+  parentIP: string=EMPTY_ADDRESS
+
 ) => {
   const metadataRendererInit = metadata != null
     ? ethers.utils.AbiCoder.prototype.encode(
@@ -177,6 +182,7 @@ export const deployDCNT4907A = async (
     {
       metadataURI,
       metadataRendererInit,
+      parentIP
     }
   );
 
@@ -197,7 +203,8 @@ export const deployDCNTCrescendo = async (
   unlockDate: number,
   royaltyBPS: number,
   metadataURI: string,
-  metadata: MetadataInit | null
+  metadata: MetadataInit | null,
+  parentIP: string=EMPTY_ADDRESS
 ) => {
   const metadataRendererInit = metadata != null
     ? ethers.utils.AbiCoder.prototype.encode(
@@ -225,6 +232,7 @@ export const deployDCNTCrescendo = async (
     {
       metadataURI,
       metadataRendererInit,
+      parentIP
     }
   );
 
@@ -284,7 +292,8 @@ export const DCNTVaultNFTCreate = async (
   metadata: MetadataInit | null,
   vaultDistributionTokenAddress: string,
   unlockDate: number,
-  supports4907: boolean
+  supports4907: boolean,
+  parentIP:string =EMPTY_ADDRESS
 ) => {
   const metadataRendererInit = metadata != null
     ? ethers.utils.AbiCoder.prototype.encode(
@@ -310,6 +319,7 @@ export const DCNTVaultNFTCreate = async (
     {
       metadataURI,
       metadataRendererInit,
+      parentIP
     },
     vaultDistributionTokenAddress,
     unlockDate,

--- a/scripts/deployDCNT721A.ts
+++ b/scripts/deployDCNT721A.ts
@@ -30,7 +30,6 @@ async function main() {
     royaltyBPS,
     metadataURI,
     metadataRendererInit,
-    null
   );
   console.log("DCNT721A deployed to: ", DCNT721A.address);
 }

--- a/scripts/deployDCNT721A.ts
+++ b/scripts/deployDCNT721A.ts
@@ -29,7 +29,8 @@ async function main() {
     maxTokenPurchase,
     royaltyBPS,
     metadataURI,
-    metadataRendererInit
+    metadataRendererInit,
+    null
   );
   console.log("DCNT721A deployed to: ", DCNT721A.address);
 }

--- a/test/DCNT4907a.ts
+++ b/test/DCNT4907a.ts
@@ -55,6 +55,7 @@ describe("DCNT4907A", async () => {
       expect(await clone.MAX_TOKENS()).to.equal(maxTokens);
       expect(await clone.tokenPrice()).to.equal(tokenPrice);
       expect(await clone.maxTokenPurchase()).to.equal(maxTokenPurchase);
+      expect(await clone.parentIP()).to.equal(parentIP.address);
     });
   });
 

--- a/test/DCNT4907a.ts
+++ b/test/DCNT4907a.ts
@@ -3,7 +3,7 @@ import { ethers } from "hardhat";
 import { before, beforeEach } from "mocha";
 import { BigNumber, Contract } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { deployDCNTSDK, deployDCNT4907A, theFuture } from "../core";
+import { deployDCNTSDK, deployDCNT4907A, theFuture, deployMockERC721 } from "../core";
 
 const name = 'Decent';
 const symbol = 'DCNT';
@@ -23,11 +23,13 @@ describe("DCNT4907A", async () => {
       sdk: Contract,
       clone: Contract,
       nft: Contract,
-      expiration: number;
+      expiration: number,
+      parentIP: Contract;
 
   before(async () => {
     [owner] = await ethers.getSigners();
     sdk = await deployDCNTSDK();
+    parentIP = await deployMockERC721()
     clone = await deployDCNT4907A(
       sdk,
       name,
@@ -37,7 +39,8 @@ describe("DCNT4907A", async () => {
       maxTokenPurchase,
       royaltyBPS,
       metadataURI,
-      metadataRendererInit
+      metadataRendererInit,
+      parentIP.address
     );
   });
 

--- a/test/DCNT721a.ts
+++ b/test/DCNT721a.ts
@@ -59,7 +59,7 @@ describe("DCNT721A", async () => {
       expect(ethers.utils.getAddress(await clone.owner())).to.equal(owner.address);
     });
 
-    it("should have the EIP-5553 based parent IP set to empty by default", async () => {
+    it("should have the EIP-5553 based parent IP set", async () => {
       expect(await clone.parentIP()).to.equal(parentIP.address);
     });
 
@@ -94,6 +94,21 @@ describe("DCNT721A", async () => {
       expect(meta.name).to.equal(`${name} 0`);
     });
 
+    it("should allow empty parent IP", async () => {
+      clone = await deployDCNT721A(
+        sdk,
+        name,
+        symbol,
+        maxTokens,
+        tokenPrice,
+        maxTokenPurchase,
+        royaltyBPS,
+        metadataURI,
+        null,
+      );
+
+      expect(await clone.parentIP()).to.equal('0x0000000000000000000000000000000000000000');
+    });
     it("should optionally set the base token URI", async () => {
       clone = await deployDCNT721A(
         sdk,

--- a/test/DCNTCrescendo.ts
+++ b/test/DCNTCrescendo.ts
@@ -3,7 +3,7 @@ import { ethers } from "hardhat";
 import { before, beforeEach } from "mocha";
 import { BigNumber, Contract } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { deployDCNTSDK, deployDCNTCrescendo, theFuture, sortByAddress, deployDCNTMetadataRenderer } from "../core";
+import { deployDCNTSDK, deployDCNTCrescendo, theFuture, sortByAddress, deployDCNTMetadataRenderer, deployMockERC721 } from "../core";
 
 const name = 'Decent';
 const symbol = 'DCNT';
@@ -29,11 +29,14 @@ describe("DCNTCrescendo", async () => {
       clone: Contract,
       crescendo: Contract,
       metadataRenderer: Contract,
-      split: any[];
+      split: any[],
+      parentIP: Contract;
+
 
   before(async () => {
     [owner] = await ethers.getSigners();
     sdk = await deployDCNTSDK();
+    parentIP = await deployMockERC721();
     clone = await deployDCNTCrescendo(
       sdk,
       name,
@@ -46,7 +49,8 @@ describe("DCNTCrescendo", async () => {
       unlockDate,
       royaltyBPS,
       metadataURI,
-      metadataRendererInit
+      metadataRendererInit,
+      parentIP.address
     );
   });
 
@@ -60,6 +64,9 @@ describe("DCNTCrescendo", async () => {
       expect(await clone.name()).to.equal(name);
       expect(await clone.symbol()).to.equal(symbol);
       expect(await clone.uri(0)).to.equal(metadataURI);
+      
+      //EIP 5553 parent IP
+      expect(await clone.parentIP()).to.equal(parentIP.address);
 
       // private state
       const key = ethers.utils.defaultAbiCoder.encode(["uint256","uint256"],[0,12]);

--- a/test/DCNTCrescendo.ts
+++ b/test/DCNTCrescendo.ts
@@ -144,7 +144,7 @@ describe("DCNTCrescendo", async () => {
         unlockDate,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
 
       await crescendo.flipSaleState();
@@ -209,7 +209,7 @@ describe("DCNTCrescendo", async () => {
         unlockDate,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
     });
 
@@ -270,7 +270,7 @@ describe("DCNTCrescendo", async () => {
         unlockDate,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
       await crescendo.flipSaleState();
       await crescendo.buy(0, { value: initialPrice });
@@ -313,7 +313,7 @@ describe("DCNTCrescendo", async () => {
         theFuture.time() + theFuture.oneDay,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
 
       await crescendo.flipSaleState();
@@ -337,7 +337,7 @@ describe("DCNTCrescendo", async () => {
         unlockDate,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
       await crescendo.flipSaleState();
       await crescendo.buy(0, { value: initialPrice });
@@ -371,7 +371,7 @@ describe("DCNTCrescendo", async () => {
         unlockDate,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
 
       await expect(
@@ -394,7 +394,7 @@ describe("DCNTCrescendo", async () => {
         unlockDate,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
       await crescendo.flipSaleState();
       await crescendo.buy(0, { value: initialPrice });
@@ -427,7 +427,7 @@ describe("DCNTCrescendo", async () => {
         unlockDate,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
 
       await expect(
@@ -448,7 +448,7 @@ describe("DCNTCrescendo", async () => {
         theFuture.time() + theFuture.oneDay,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
 
       await crescendo.flipSaleState();
@@ -483,7 +483,7 @@ describe("DCNTCrescendo", async () => {
         theFuture.time() + theFuture.oneDay,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
 
       await expect(
@@ -524,7 +524,7 @@ describe("DCNTCrescendo", async () => {
         unlockDate,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
 
       await freshNFT.flipSaleState();
@@ -553,7 +553,7 @@ describe("DCNTCrescendo", async () => {
         unlockDate,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
       );
 
       metadataRenderer = await deployDCNTMetadataRenderer();

--- a/test/DCNTRentalMarket.ts
+++ b/test/DCNTRentalMarket.ts
@@ -21,12 +21,14 @@ describe("DCNTRentalMarket", async () => {
       renter: SignerWithAddress,
       sdk: Contract,
       nft: Contract,
-      rentalMarket: Contract;
+      rentalMarket: Contract,
+      parentIP: Contract
 
   describe("constructor()", async () => {
     before(async () => {
       [owner, fan, renter] = await ethers.getSigners();
       sdk = await deployDCNTSDK();
+      parentIP = await deployMockERC721();
       nft = await deployDCNT4907A(
         sdk,
         name,
@@ -36,7 +38,8 @@ describe("DCNTRentalMarket", async () => {
         maxTokenPurchase,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
+        parentIP.address
       );
       await nft.flipSaleState();
       await nft.connect(fan).mint(1, { value: tokenPrice });

--- a/test/DCNTSDK.ts
+++ b/test/DCNTSDK.ts
@@ -13,7 +13,8 @@ import {
   deployDCNTStaking,
   deployDCNTMetadataRenderer,
   deployContract,
-  theFuture
+  theFuture,
+  deployMockERC721
 } from "../core";
 
 describe("DCNTSDK", async () => {
@@ -22,7 +23,8 @@ describe("DCNTSDK", async () => {
       metadataRenderer: Contract,
       contractRegistry: Contract,
       sdk: Contract,
-      clone: Contract;
+      clone: Contract,
+      parentIP: Contract;
 
   before(async () => {
     [owner] = await ethers.getSigners();
@@ -30,6 +32,7 @@ describe("DCNTSDK", async () => {
     metadataRenderer = await deployDCNTMetadataRenderer();
     contractRegistry = await deployContract('DCNTRegistry');
     sdk = await deployDCNTSDK(implementations, metadataRenderer, contractRegistry);
+    parentIP = await deployMockERC721();
   });
 
   describe("constructor()", async () => {
@@ -78,7 +81,8 @@ describe("DCNTSDK", async () => {
         maxTokenPurchase,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
+        parentIP.address
       );
     });
 
@@ -112,7 +116,8 @@ describe("DCNTSDK", async () => {
         maxTokenPurchase,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
+        parentIP.address
       );
     });
 
@@ -153,7 +158,8 @@ describe("DCNTSDK", async () => {
         unlockDate,
         royaltyBPS,
         metadataURI,
-        metadataRendererInit
+        metadataRendererInit,
+        parentIP.address
       );
     });
 


### PR DESCRIPTION
Happy to start contributing.
I've added basic support for a new field inside metadata structure called "parentIP" which is optional but would allow pointing to a parent musical IP on chain as described in https://eips.ethereum.org/EIPS/eip-5553

Since the metadata structure is sent to DCNT721A, DCNTCrescendo and DCNT4907A, it was relatively easy to add support for it in all three, with a default value of empty address.

looking forward to hearing feedback.