### PR TITLE
Add clone address return value on 721A

### DIFF
--- a/contracts/DCNTSDK.sol
+++ b/contracts/DCNTSDK.sol
@@ -107,6 +107,7 @@ contract DCNTSDK is Ownable {
     require(success);
     IDCNTRegistry(contractRegistry).register(msg.sender, clone, "DCNT721A");
     emit DeployDCNT721A(clone);
+    return clone;
   }
 
   /// @notice deploy and initialize a ZKEdition clone


### PR DESCRIPTION
Allow Solidity smart contracts to receive the address of the clone during deployment.